### PR TITLE
fix "fall damage cap" code for minions being in the wrong spot

### DIFF
--- a/addons/sourcemod/scripting/vsh/client.sp
+++ b/addons/sourcemod/scripting/vsh/client.sp
@@ -328,12 +328,15 @@ public Action Client_OnTakeDamage(int victim, int &attacker, int &inflictor, flo
 	char weaponClass[32];
 	if (weapon >= 0) GetEdictClassname(weapon, weaponClass, sizeof(weaponClass));
 
+	// is valid victim
 	if (0 < victim <= MaxClients && IsClientInGame(victim) && GetClientTeam(victim) > 1)
 	{
 		bool bIsVictimBoss = g_clientBoss[victim].IsValid();
 		bool bVictimUbered = TF2_IsUbercharged(victim);
 		if (bIsVictimBoss)
 			finalAction = g_clientBoss[victim].OnTakeDamage(attacker, inflictor, damage, damagetype, weapon, damageForce, damagePosition, damagecustom);
+		
+		// is valid attacker
 		if (0 < attacker <= MaxClients && IsClientInGame(attacker))
 		{
 			if (!g_clientBoss[attacker].IsValid()) // Regular players


### PR DESCRIPTION
previous implementation of the "fall damage cap" did not work as I did not realise it was residing in a condition of (if attacker is a valid client), thus the code never worked. now it is in the correct spot.

also the commit timeline is messed up because of some shitting with my client. only 1 file has been changed.